### PR TITLE
Strip invisible Unicode from tool descriptions

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -17,6 +17,7 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { sanitizeTools } from "./shared.js";
 
 const SKIP = new Set(["shared.js"]);
 
@@ -41,7 +42,7 @@ export async function startServer(modulesDir, { name = "mcp-slim", version = "0.
     }
   }
 
-  const allTools = modules.flatMap(m => m.tools || []);
+  const allTools = sanitizeTools(modules.flatMap(m => m.tools || []));
 
   const seenTools = new Set();
   for (const tool of allTools) {

--- a/src/shared.js
+++ b/src/shared.js
@@ -427,6 +427,52 @@ export function mdTable(headers, rows) {
   return lines.join("\n");
 }
 
+// ── Tool description sanitization ─────────────────────────────────────────
+
+/**
+ * Strip invisible/non-printable Unicode codepoints from a string.
+ * Preserves normal whitespace (space, tab, newline, carriage return).
+ * Targets: control chars, zero-width chars, directional overrides,
+ * Unicode Tags (U+E0001-U+E007F), variation selectors supplement.
+ */
+const INVISIBLE_RE = /[\x00-\x08\x0E-\x1F\x7F-\x9F\xAD\u200B-\u200F\u2028-\u202F\u2060-\u2064\u2066-\u206F\uFEFF\uFFF9-\uFFFB\u{E0001}-\u{E007F}\u{E0100}-\u{E01EF}]/gu;
+
+export function stripInvisible(str) {
+  if (typeof str !== "string") return str;
+  return str.replace(INVISIBLE_RE, "");
+}
+
+function sanitizeSchema(schema) {
+  if (!schema || typeof schema !== "object") return schema;
+  const result = { ...schema };
+  if (typeof result.description === "string") {
+    result.description = stripInvisible(result.description);
+  }
+  if (result.properties) {
+    result.properties = Object.fromEntries(
+      Object.entries(result.properties).map(([k, v]) => [k, sanitizeSchema(v)])
+    );
+  }
+  if (result.items) {
+    result.items = sanitizeSchema(result.items);
+  }
+  return result;
+}
+
+/**
+ * Sanitize tool definitions by stripping invisible Unicode from
+ * description fields (tool-level and nested inputSchema properties).
+ * Closes the prompt injection vector where hidden instructions are
+ * embedded in MCP tool descriptions using non-printable codepoints.
+ */
+export function sanitizeTools(tools) {
+  return tools.map(tool => ({
+    ...tool,
+    description: stripInvisible(tool.description),
+    inputSchema: sanitizeSchema(tool.inputSchema),
+  }));
+}
+
 // ── MCP response wrappers ──────────────────────────────────────────────────
 
 /** Wrap text in MCP tool response format. */


### PR DESCRIPTION
## Summary

- Adds `sanitizeTools()` / `stripInvisible()` to strip non-printable Unicode codepoints from tool descriptions at load time
- Covers Unicode Tags (U+E0001-E007F), zero-width chars, directional overrides, control chars, BOM, variation selectors
- Recursively sanitizes tool-level and nested `inputSchema` property descriptions
- Normal whitespace preserved, legitimate descriptions pass through unchanged

Closes #1

## Context

MCP tool descriptions can contain invisible Unicode that is parsed by the model as instructions but invisible to humans. Since mcp-slim sits between the MCP server and Claude, stripping these at the proxy layer is a low-cost defense against this prompt injection vector.

## Test plan

- [x] Verified Unicode Tags block (U+E0001-E007F) stripped correctly
- [x] Verified zero-width chars (U+200B, U+FEFF) stripped correctly  
- [x] Verified normal text with newlines/tabs passes through unchanged
- [x] Verified recursive sanitization of nested inputSchema properties
